### PR TITLE
Maprender

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
-maprender-test
+crystals
 autodoc
+modules/
+tests/
 *.o
 *.so
 *.d
+*.*~

--- a/src/map.h
+++ b/src/map.h
@@ -65,12 +65,15 @@ typedef unsigned short layer_t; /**< Type for layer data. */
  *
  *  This contains the tile data and eventually the object list for a
  *  map.
+ *
+ *  @note width and height are currently stored as ints due to quirks
+ *        in the map viewing code. This may change later.
  */
 
 struct map
 {
-  unsigned int width;       /**< Width of the map, in tiles. */
-  unsigned int height;      /**< Height of the map, in tiles. */
+  int width;                /**< Width of the map, in tiles. */
+  int height;               /**< Height of the map, in tiles. */
   unsigned char num_layers; /**< Number of arrays to store in the map. */
   layer_t **data_layers;    /**< Pointers to map layer arrays. */
 };

--- a/src/mapview.c
+++ b/src/mapview.c
@@ -328,7 +328,7 @@ void
 render_map_layer (struct map_view *mapview, unsigned char layer)
 {
   short x, y;
-  long true_x, true_y, x_offset, y_offset;
+  int true_x, true_y, x_offset, y_offset;
   struct map *map;
 
   map = mapview->map;
@@ -463,12 +463,12 @@ scroll_map (struct map_view *mapview, int direction)
 
 int
 mark_dirty_rect (struct map_view *mapview,
-                 long start_x,
-                 long start_y,
-                 unsigned int width,
-                 unsigned int height)
+                 int start_x,
+                 int start_y,
+                 int width,
+                 int height)
 {
-  long x, y;
+  int x, y;
 
   /* Sanity checking. */
 
@@ -478,7 +478,7 @@ mark_dirty_rect (struct map_view *mapview,
       return FAILURE;
     }
 
-  if (width == 0 || height == 0)
+  if (width <= 0 || height <= 0)
     {
       fprintf (stderr, "MAPVIEW: Error: Rect dirtying passed insane W/H.\n");
       return FAILURE;

--- a/src/mapview.h
+++ b/src/mapview.h
@@ -71,11 +71,11 @@ struct object_image
                             on-image rectangle from which to source
                             the rendered image, in pixels. */
 
-  unsigned int map_x;    /**< X co-ordinate of the left edge of the
+  int map_x;             /**< X co-ordinate of the left edge of the
                             on-map rectangle in which to render the
                             image, in pixels. */
 
-  unsigned int map_y;    /**< Y co-ordinate of the top edge of the
+  int map_y;             /**< Y co-ordinate of the top edge of the
                             on-map rectangle in which to render the
                             image, in pixels. */
 
@@ -268,10 +268,10 @@ scroll_map (struct map_view *mapview, int direction);
 
 int
 mark_dirty_rect (struct map_view *mapview,
-                 long start_x,
-                 long start_y,
-                 unsigned int width,
-                 unsigned int height);
+                 int start_x,
+                 int start_y,
+                 int width,
+                 int height);
 
 /** De-initialise a mapview.
  *

--- a/src/object.c
+++ b/src/object.c
@@ -381,10 +381,10 @@ dirty_object_test (struct hash_object *hash_object, va_list ap)
 {
   struct object_t *object;
   struct map_view *mapview;
-  long start_x;
-  long start_y;
-  unsigned int width;
-  unsigned int height;
+  int start_x;
+  int start_y;
+  int width;
+  int height;
 
   /* Sanity-check the hash object. */
 
@@ -408,8 +408,8 @@ dirty_object_test (struct hash_object *hash_object, va_list ap)
     return SUCCESS;
 
   mapview = va_arg (ap, struct map_view *);
-  start_x = va_arg (ap, long);
-  start_y = va_arg (ap, long);
+  start_x = va_arg (ap, int);
+  start_y = va_arg (ap, int);
   width   = va_arg (ap, unsigned int);
   height  = va_arg (ap, unsigned int);
 


### PR DESCRIPTION
Bug fix (should have been done on staging QA, really) making previous maprender commit work on 32-bit systems.

Side-effects:
- Map maximum width and height are halved from 4294967295 to 2147483647 each (since both are now stored as int instead of unsigned int for compatibility with the map render code). This may change back later, but isn't really much of a problem (are we ever going to have a 2147483647x2147483647 map?)

Other changes:
- Main directory gitignore changed so it ignores _._~ backup files, crystals (as opposed to maprender-test) and the test and modules directories.
