### PR TITLE
Giselher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ WARN     := -Wall -Wextra -Wshadow -Wpointer-arith -Wcast-align \
             -Wredundant-decls -Wnested-externs -Winline -Wno-long-long \
             -Wconversion -Wstrict-prototypes
 
-LIBS     := -ldl 
+LIBS     := -ldl -lpthread 
 CFLAGS   := -ansi -pedantic -O2 -ggdb -DDEFMODPATH="\"$(MODPATH)\"" $(WARN)
 
 ## Rules ##

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ $(BIN): $(OBJ) $(SO)
 
 clean: clean-tests clean-doc clean-modules
 	@echo "Cleaning..."
-	-@$(RM) $(BIN) *.o *.d *.so &>/dev/null
+	-@$(RM) $(BIN) $(SRCDIR)/*.{o,d,so} &>/dev/null
 
 ### Modules
 $(SRCDIR)/$(MODDIR)/gfx-sdl.so: LIBS   += `sdl-config --libs` -lSDL_image

--- a/src/modules/bindings-lua.c
+++ b/src/modules/bindings-lua.c
@@ -36,7 +36,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/** @file   src/modules/bindings-lua.h
+/** @file   src/modules/bindings-lua.c
  *  @author Alexander Preisinger
  *  @brief  Lua module for scripting.
  */
@@ -94,6 +94,7 @@ parameter_check (lua_State *L, const char *func_name, const char sig[])
   int pars;
   int pas_pars;
 
+  /* to prevent type conversation warnings on 64 bit systems */
   pars = (int) strlen (sig);
   pas_pars = lua_gettop (L);
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -48,6 +48,57 @@
 #include "util.h"
 #include "parser.h"
 
+
+/* STATIC FUNCTION PROTOTYPES */
+
+/** Internal function for getting the value.
+ *
+ *  @param key   The key to search for.
+ *  @param node  The next branch to search in.
+ *
+ *  @return Return the value to the appropriate key or NULL if none is found.
+ */
+
+static char*
+get_value (const char *key, struct node_t *node);
+
+
+/** Internal function for adding a key-value pair to the tree.
+ *
+ *  @param key   The string which will be added as key.
+ *  @param value The string which will be added as key.
+ *  @param node  The branch in which the key-value pair will be added.
+ *
+ *  @return Returns SUCCESS, if the key-value pair can be added, if not or
+ *  the key already exists return FAILURE. (Defined in util.h)
+ */
+
+static int
+add_pair (char *key, char *value, struct node_t *node);
+
+
+/** Internal function for initializing a node.
+ *
+ *  @param node The node which will be initialized.
+ *
+ *  @param Return the initialized node.
+ */
+
+static struct node_t*
+node_init (struct node_t *node);
+
+
+/** Internal function for freeing allocated memory in nodes.
+ *
+ * @param node The data in the node will be freed.
+ */
+
+static void
+free_node (struct node_t *node);
+
+
+/* DEFINITIONS */
+
 /* Initializes the parser. */
 
 void

--- a/src/parser.h
+++ b/src/parser.h
@@ -102,53 +102,6 @@ config_parse_file (const char *path_name);
 char*
 config_get_value (const char *key);
 
-
-/** Internal function for getting the value.
- *
- *  @param key   The key to search for.
- *  @param node  The next branch to search in.
- *
- *  @return Return the value to the appropriate key or NULL if none is found.
- */
-
-static char*
-get_value (const char *key, struct node_t *node);
-
-
-/** Internal function for adding a key-value pair to the tree.
- *
- *  @param key   The string which will be added as key.
- *  @param value The string which will be added as key.
- *  @param node  The branch in which the key-value pair will be added.
- *
- *  @return Returns SUCCESS, if the key-value pair can be added, if not or
- *  the key already exists return FAILURE. (Defined in util.h)
- */
-
-static int
-add_pair (char *key, char *value, struct node_t *node);
-
-
-/** Internal function for initializing a node.
- *
- *  @param node The node which will be initialized.
- *
- *  @param Return the initialized node.
- */
-
-static struct node_t*
-node_init (struct node_t *node);
-
-
-/** Internal function for freeing allocated memory in nodes.
- *
- * @param node The data in the node will be freed.
- */
-
-static void
-free_node (struct node_t *node);
-
-
 /** Clean up the parser.
  *
  *  Free all allocated memory.

--- a/tools/valgrind-python.supp
+++ b/tools/valgrind-python.supp
@@ -1,0 +1,391 @@
+#
+# This is a valgrind suppression file that should be used when using valgrind.
+#
+#  Here's an example of running valgrind:
+#
+#	cd python/dist/src
+#	valgrind --tool=memcheck --suppressions=Misc/valgrind-python.supp \
+#		./python -E -tt ./Lib/test/regrtest.py -u bsddb,network
+#
+# You must edit Objects/obmalloc.c and uncomment Py_USING_MEMORY_DEBUGGER
+# to use the preferred suppressions with Py_ADDRESS_IN_RANGE.
+#
+# If you do not want to recompile Python, you can uncomment
+# suppressions for PyObject_Free and PyObject_Realloc.
+#
+# See Misc/README.valgrind for more information.
+
+# all tool names: Addrcheck,Memcheck,cachegrind,helgrind,massif
+{
+   ADDRESS_IN_RANGE/Invalid read of size 4
+   Memcheck:Addr4
+   fun:Py_ADDRESS_IN_RANGE
+}
+
+{
+   ADDRESS_IN_RANGE/Invalid read of size 4
+   Memcheck:Value4
+   fun:Py_ADDRESS_IN_RANGE
+}
+
+{
+   ADDRESS_IN_RANGE/Invalid read of size 8 (x86_64 aka amd64)
+   Memcheck:Value8
+   fun:Py_ADDRESS_IN_RANGE
+}
+
+{
+   ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
+   Memcheck:Cond
+   fun:Py_ADDRESS_IN_RANGE
+}
+
+#
+# Leaks (including possible leaks)
+#    Hmmm, I wonder if this masks some real leaks.  I think it does.
+#    Will need to fix that.
+#
+
+{
+   Suppress leaking the GIL.  Happens once per process, see comment in ceval.c.
+   Memcheck:Leak
+   fun:malloc
+   fun:PyThread_allocate_lock
+   fun:PyEval_InitThreads
+}
+
+{
+   Suppress leaking the GIL after a fork.
+   Memcheck:Leak
+   fun:malloc
+   fun:PyThread_allocate_lock
+   fun:PyEval_ReInitThreads
+}
+
+{
+   Suppress leaking the autoTLSkey.  This looks like it shouldn't leak though.
+   Memcheck:Leak
+   fun:malloc
+   fun:PyThread_create_key
+   fun:_PyGILState_Init
+   fun:Py_InitializeEx
+   fun:Py_Main
+}
+
+{
+   Hmmm, is this a real leak or like the GIL?
+   Memcheck:Leak
+   fun:malloc
+   fun:PyThread_ReInitTLS
+}
+
+{
+   Handle PyMalloc confusing valgrind (possibly leaked)
+   Memcheck:Leak
+   fun:realloc
+   fun:_PyObject_GC_Resize
+   fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
+}
+
+{
+   Handle PyMalloc confusing valgrind (possibly leaked)
+   Memcheck:Leak
+   fun:malloc
+   fun:_PyObject_GC_New
+   fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
+}
+
+{
+   Handle PyMalloc confusing valgrind (possibly leaked)
+   Memcheck:Leak
+   fun:malloc
+   fun:_PyObject_GC_NewVar
+   fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
+}
+
+#
+# Non-python specific leaks
+#
+
+{
+   Handle pthread issue (possibly leaked)
+   Memcheck:Leak
+   fun:calloc
+   fun:allocate_dtv
+   fun:_dl_allocate_tls_storage
+   fun:_dl_allocate_tls
+}
+
+{
+   Handle pthread issue (possibly leaked)
+   Memcheck:Leak
+   fun:memalign
+   fun:_dl_allocate_tls_storage
+   fun:_dl_allocate_tls
+}
+
+{
+  ADDRESS_IN_RANGE/Invalid read of size 4
+   Memcheck:Addr4
+   fun:PyObject_Free
+}
+
+{
+   ADDRESS_IN_RANGE/Invalid read of size 4
+   Memcheck:Value4
+   fun:PyObject_Free
+}
+
+{
+   ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
+   Memcheck:Cond
+   fun:PyObject_Free
+}
+
+{
+   ADDRESS_IN_RANGE/Invalid read of size 4
+   Memcheck:Addr4
+   fun:PyObject_Realloc
+}
+
+{
+   ADDRESS_IN_RANGE/Invalid read of size 4
+   Memcheck:Value4
+   fun:PyObject_Realloc
+}
+
+{
+   ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
+   Memcheck:Cond
+   fun:PyObject_Realloc
+}
+
+###
+### All the suppressions below are for errors that occur within libraries
+### that Python uses.  The problems to not appear to be related to Python's
+### use of the libraries.
+###
+
+{
+   Generic ubuntu ld problems
+   Memcheck:Addr8
+   obj:/lib/ld-2.4.so
+   obj:/lib/ld-2.4.so
+   obj:/lib/ld-2.4.so
+   obj:/lib/ld-2.4.so
+}
+
+{
+   Generic gentoo ld problems
+   Memcheck:Cond
+   obj:/lib/ld-2.3.4.so
+   obj:/lib/ld-2.3.4.so
+   obj:/lib/ld-2.3.4.so
+   obj:/lib/ld-2.3.4.so
+}
+
+{
+   DBM problems, see test_dbm
+   Memcheck:Param
+   write(buf)
+   fun:write
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   fun:dbm_close
+}
+
+{
+   DBM problems, see test_dbm
+   Memcheck:Value8
+   fun:memmove
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   fun:dbm_store
+   fun:dbm_ass_sub
+}
+
+{
+   DBM problems, see test_dbm
+   Memcheck:Cond
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   fun:dbm_store
+   fun:dbm_ass_sub
+}
+
+{
+   DBM problems, see test_dbm
+   Memcheck:Cond
+   fun:memmove
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   fun:dbm_store
+   fun:dbm_ass_sub
+}
+
+{
+   GDBM problems, see test_gdbm
+   Memcheck:Param
+   write(buf)
+   fun:write
+   fun:gdbm_open
+
+}
+
+{
+   ZLIB problems, see test_gzip
+   Memcheck:Cond
+   obj:/lib/libz.so.1.2.3
+   obj:/lib/libz.so.1.2.3
+   fun:deflate
+}
+
+{
+   Avoid problems w/readline doing a putenv and leaking on exit
+   Memcheck:Leak
+   fun:malloc
+   fun:xmalloc
+   fun:sh_set_lines_and_columns
+   fun:_rl_get_screen_size
+   fun:_rl_init_terminal_io
+   obj:/lib/libreadline.so.4.3
+   fun:rl_initialize
+}
+
+###
+### These occur from somewhere within the SSL, when running
+###  test_socket_sll.  They are too general to leave on by default.
+###
+###{
+###   somewhere in SSL stuff
+###   Memcheck:Cond
+###   fun:memset
+###}
+###{
+###   somewhere in SSL stuff
+###   Memcheck:Value4
+###   fun:memset
+###}
+###
+###{
+###   somewhere in SSL stuff
+###   Memcheck:Cond
+###   fun:MD5_Update
+###}
+###
+###{
+###   somewhere in SSL stuff
+###   Memcheck:Value4
+###   fun:MD5_Update
+###}
+
+#
+# All of these problems come from using test_socket_ssl
+#
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:BN_bin2bn
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:BN_num_bits_word
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Value4
+   fun:BN_num_bits_word
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:BN_mod_exp_mont_word
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:BN_mod_exp_mont
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Param
+   write(buf)
+   fun:write
+   obj:/usr/lib/libcrypto.so.0.9.7
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:RSA_verify
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Value4
+   fun:RSA_verify
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Value4
+   fun:DES_set_key_unchecked
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Value4
+   fun:DES_encrypt2
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   obj:/usr/lib/libssl.so.0.9.7
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Value4
+   obj:/usr/lib/libssl.so.0.9.7
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:BUF_MEM_grow_clean
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:memcpy
+   fun:ssl3_read_bytes
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:SHA1_Update
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Value4
+   fun:SHA1_Update
+}
+
+

--- a/tools/valgrind-python.supp
+++ b/tools/valgrind-python.supp
@@ -165,100 +165,100 @@
 ### that Python uses.  The problems to not appear to be related to Python's
 ### use of the libraries.
 ###
-
-{
-   Generic ubuntu ld problems
-   Memcheck:Addr8
-   obj:/lib/ld-2.4.so
-   obj:/lib/ld-2.4.so
-   obj:/lib/ld-2.4.so
-   obj:/lib/ld-2.4.so
-}
-
-{
-   Generic gentoo ld problems
-   Memcheck:Cond
-   obj:/lib/ld-2.3.4.so
-   obj:/lib/ld-2.3.4.so
-   obj:/lib/ld-2.3.4.so
-   obj:/lib/ld-2.3.4.so
-}
-
-{
-   DBM problems, see test_dbm
-   Memcheck:Param
-   write(buf)
-   fun:write
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   fun:dbm_close
-}
-
-{
-   DBM problems, see test_dbm
-   Memcheck:Value8
-   fun:memmove
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   fun:dbm_store
-   fun:dbm_ass_sub
-}
-
-{
-   DBM problems, see test_dbm
-   Memcheck:Cond
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   fun:dbm_store
-   fun:dbm_ass_sub
-}
-
-{
-   DBM problems, see test_dbm
-   Memcheck:Cond
-   fun:memmove
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   obj:/usr/lib/libdb1.so.2
-   fun:dbm_store
-   fun:dbm_ass_sub
-}
-
-{
-   GDBM problems, see test_gdbm
-   Memcheck:Param
-   write(buf)
-   fun:write
-   fun:gdbm_open
-
-}
-
-{
-   ZLIB problems, see test_gzip
-   Memcheck:Cond
-   obj:/lib/libz.so.1.2.3
-   obj:/lib/libz.so.1.2.3
-   fun:deflate
-}
-
-{
-   Avoid problems w/readline doing a putenv and leaking on exit
-   Memcheck:Leak
-   fun:malloc
-   fun:xmalloc
-   fun:sh_set_lines_and_columns
-   fun:_rl_get_screen_size
-   fun:_rl_init_terminal_io
-   obj:/lib/libreadline.so.4.3
-   fun:rl_initialize
-}
-
+###
+###{
+###   Generic ubuntu ld problems
+###   Memcheck:Addr8
+###   obj:/lib/ld-2.4.so
+###   obj:/lib/ld-2.4.so
+###   obj:/lib/ld-2.4.so
+###   obj:/lib/ld-2.4.so
+###}
+###
+###{
+###   Generic gentoo ld problems
+###   Memcheck:Cond
+###   obj:/lib/ld-2.3.4.so
+###   obj:/lib/ld-2.3.4.so
+###   obj:/lib/ld-2.3.4.so
+###   obj:/lib/ld-2.3.4.so
+###}
+###
+###{
+###   DBM problems, see test_dbm
+###   Memcheck:Param
+###   write(buf)
+###   fun:write
+###   obj:/usr/lib/libdb1.so.2
+###   obj:/usr/lib/libdb1.so.2
+###   obj:/usr/lib/libdb1.so.2
+###   obj:/usr/lib/libdb1.so.2
+###   fun:dbm_close
+###}
+###
+###{
+###   DBM problems, see test_dbm
+###   Memcheck:Value8
+###   fun:memmove
+###   obj:/usr/lib/libdb1.so.2
+###   obj:/usr/lib/libdb1.so.2
+###   obj:/usr/lib/libdb1.so.2
+###   obj:/usr/lib/libdb1.so.2
+###   fun:dbm_store
+###   fun:dbm_ass_sub
+###}
+###
+###{
+###   DBM problems, see test_dbm
+###   Memcheck:Cond
+###   obj:/usr/lib/libdb1.so.2
+###   obj:/usr/lib/libdb1.so.2
+###   obj:/usr/lib/libdb1.so.2
+###   fun:dbm_store
+###   fun:dbm_ass_sub
+###}
+###
+###{
+###   DBM problems, see test_dbm
+###   Memcheck:Cond
+###   fun:memmove
+###   obj:/usr/lib/libdb1.so.2
+###   obj:/usr/lib/libdb1.so.2
+###   obj:/usr/lib/libdb1.so.2
+###   obj:/usr/lib/libdb1.so.2
+###   fun:dbm_store
+###   fun:dbm_ass_sub
+###}
+###
+###{
+###   GDBM problems, see test_gdbm
+###   Memcheck:Param
+###   write(buf)
+###   fun:write
+###   fun:gdbm_open
+###
+###}
+###
+###{
+###   ZLIB problems, see test_gzip
+###   Memcheck:Cond
+###   obj:/lib/libz.so.1.2.3
+###   obj:/lib/libz.so.1.2.3
+###   fun:deflate
+###}
+###
+###{
+###   Avoid problems w/readline doing a putenv and leaking on exit
+###   Memcheck:Leak
+###   fun:malloc
+###   fun:xmalloc
+###   fun:sh_set_lines_and_columns
+###   fun:_rl_get_screen_size
+###   fun:_rl_init_terminal_io
+###   obj:/lib/libreadline.so.4.3
+###   fun:rl_initialize
+###}
+###
 ###
 ### These occur from somewhere within the SSL, when running
 ###  test_socket_sll.  They are too general to leave on by default.


### PR DESCRIPTION
- Fixed the clean command in the Makefile.
- Moved the static prototypes to the source files.
- Minor documentations.
- Added python suppression file for valgrind ( --suppressions=./tools/valgrind-python.supp )
- [new commit] Added -lpthread to the makefile to fix usage with gdb (temporary)

About the suppression file, I found out that valgrinds detects often false errors and allocations, because how python memory uses. To get a right valgrind output you have to recompile python with --without-pymalloc --without-pydebug and --with-valgrind. Well, with pymalloc python is faster, but It reserves memory till the end because it reuses it or might uses it later and It appears like leaks, lots of leaks. That doesn't mean that python doesn.t leak, but the python people are eager to provide an efficent and fast python.

Links:
http://www.python.org/dev/faq/#can-i-run-valgrind-against-python
http://svn.python.org/view/python/trunk/Misc/README.valgrind?revision=45472&view=markup
