### PR TITLE
Maprender

### DIFF
--- a/src/graphics.c
+++ b/src/graphics.c
@@ -116,7 +116,7 @@ load_image (const char filename[])
 
   if (filename == NULL)
     {
-      fprintf (stderr, "GFX: Error: Filename is NULL.\n");
+      fatal ("GFX - load_image - Filename is NULL.");
       return NULL;
     }
 
@@ -126,8 +126,8 @@ load_image (const char filename[])
 
   if (data == NULL)
     {
-      fprintf (stderr, "GFX: Error: Couldn't load image data for %s.\n", 
-               filename);
+      fatal ("GFX - load_image - Couldn't load image data for %s.", 
+             filename);
       return NULL;
     }
 
@@ -140,8 +140,8 @@ load_image (const char filename[])
 
   if (image == NULL)
     {
-      fprintf (stderr, "GFX: Error: Hash object create failed for %s.\n", 
-               filename);
+      fatal ("GFX - load_image - Hash object create failed for %s.", 
+             filename);
       free_image (data);
       return NULL;
     }
@@ -156,7 +156,7 @@ free_image (void *image)
 {
   if (image == NULL)
     {
-      fprintf (stderr, "GRAPHICS: Error: Tried to free NULL image.\n");
+      error ("GFX - free_image - Tried to free NULL image.");
     }
 
   (*g_modules.gfx.free_image_data) (image);
@@ -182,8 +182,8 @@ draw_image (const char filename[],
 
   if (img == NULL)
     {
-      fprintf (stderr, "GFX: Error: Draw-time image load failure for %s.\n", 
-               filename);
+      error ("GFX - draw_image - Image load failure for %s.", 
+             filename);
 
       return FAILURE;
     }

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -58,6 +58,7 @@ enum
                        pixel.) */
   };
 
+
 /** Initialise the graphics subsystem.
  *
  *  @return  SUCCESS if the graphics subsystem was initialised
@@ -66,6 +67,7 @@ enum
 
 int
 init_graphics (void);
+
 
 /** Fill the screen with the given colour.
  *
@@ -84,6 +86,7 @@ fill_screen (unsigned char red,
              unsigned char green,
              unsigned char blue);
 
+
 /** Load an image.
  *
  *  This does not need to be called directly in normal circumstances,
@@ -96,6 +99,12 @@ fill_screen (unsigned char red,
  *  already been loaded.  Functions calling load_image should check
  *  beforehand that the image has not been loaded.
  *
+ *  @note  It is safe to directly use the pointer returned, for
+ *         example to pass its data member to draw_image_direct, so
+ *         long as the image is known to still be loaded.  This can be
+ *         used to speed up successive drawing calls after an image
+ *         load check.
+ *
  *  @param filename  The filename of the image to load.
  *
  *  @return  a hash_object encapsulating the image data if
@@ -104,6 +113,7 @@ fill_screen (unsigned char red,
 
 struct hash_object *
 load_image (const char filename[]);
+
 
 /** Free image data.
  *
@@ -115,6 +125,7 @@ load_image (const char filename[]);
 
 void
 free_image (void *image);
+
 
 /** Draw a rectangular portion of an image on-screen.
  *
@@ -152,6 +163,42 @@ draw_image (const char filename[],
             unsigned short width,
             unsigned short height);
 
+
+/** Draw a rectangular portion of an image on-screen, using a direct
+ *  pointer to the driver-specific image data.
+ *
+ *  @param data      The void pointer to the image data.
+ *
+ *  @param image_x   The X-coordinate of the left edge of the
+ *                   on-image rectangle to display.
+ *
+ *  @param image_y   The Y-coordinate of the top edge of the
+ *                   on-image rectangle to display.
+ *
+ *  @param screen_x  The X-coordinate of the left edge of the
+ *                   on-screen rectangle to place the image in.
+ *
+ *  @param screen_y  The Y-coordinate of the top edge of the
+ *                   on-screen rectangle to place the image in.
+ *
+ *  @param width     The width of the rectangle.
+ *
+ *  @param height    The height of the rectangle.
+ *
+ *  @return  SUCCESS for success, FAILURE otherwise. In most
+ *           cases, a failure will simply cause the image to not appear.
+ */
+
+int
+draw_image_direct (void *data,
+                   short image_x,
+                   short image_y,
+                   short screen_x,
+                   short screen_y,
+                   unsigned short width,
+                   unsigned short height);
+
+
 /** Delete an image previously loaded into the image cache.
  *
  *  @param filename  Filename of the image.
@@ -162,10 +209,12 @@ draw_image (const char filename[],
 int
 delete_image (const char filename[]);
 
+
 /** Delete all images in the image cache. */
 
 void
 clear_images (void);
+
 
 /** Retrieve an image from the image cache.
  *
@@ -178,10 +227,12 @@ clear_images (void);
 struct hash_object *
 find_image (const char filename[]);
 
+
 /** Update the screen. */
 
 void
 update_screen (void);
+
 
 /** Scroll the screen one pixel in the given direction.
  *
@@ -196,9 +247,11 @@ update_screen (void);
 void
 scroll_screen (unsigned int direction);
 
+
 /** Clean up the graphics subsystem. */
 
 void
 cleanup_graphics (void);
 
-#endif /* _GRAPHICS_H */
+
+#endif /* not _GRAPHICS_H */

--- a/src/hash.c
+++ b/src/hash.c
@@ -316,17 +316,15 @@ find_hash_object (struct hash_object *head[],
 int
 apply_to_hash_objects (struct hash_object *head[], 
                        int (*function) (struct hash_object *object, 
-                                        va_list ap),
-                       ...)
+                                        void *data),
+                       void *data)
 {
   int i;
   int result;
   int temp_result;
-  va_list ap;
   struct hash_object *hash_object;
 
   result = SUCCESS;
-  va_start (ap, function);
 
   for (i = 0; i < HASH_VALS; i++)
     {
@@ -334,14 +332,12 @@ apply_to_hash_objects (struct hash_object *head[],
            hash_object != NULL;
            hash_object = hash_object->next)
         {
-          temp_result = function (hash_object, ap);
+          temp_result = function (hash_object, data);
 
           if (temp_result == FAILURE)
             result = FAILURE;
         }
     }
-
-  va_end (ap);
 
   return result;
 }

--- a/src/hash.h
+++ b/src/hash.h
@@ -190,9 +190,10 @@ find_hash_object (struct hash_object *head[],
  *
  *  @param function  Pointer to the function to apply to the
  *                   object.  The function must take the hash object
- *                   as first parameter followed by a variadic
- *                   parameter set (va_list), and return a
- *                   SUCCESS/FAILURE int.
+ *                   as first parameter followed by a void pointer for
+ *                   data, and return a SUCCESS/FAILURE int.
+ *
+ *  @param data      Void pointer to the data to pass to the function.
  *
  *  @return SUCCESS if all applications of the function succeeded,
  *  FAILURE otherwise.
@@ -201,7 +202,7 @@ find_hash_object (struct hash_object *head[],
 int
 apply_to_hash_objects (struct hash_object *head[], 
                        int (*function) (struct hash_object *object, 
-                                        va_list ap),
-                       ...);
+                                        void *data),
+                       void *data);
 
 #endif /* not _HASH_H */

--- a/src/main.c
+++ b/src/main.c
@@ -108,8 +108,6 @@ init (void)
       return FAILURE;
     }
 
-  free (module_path);
-
   if (init_graphics () == FAILURE)
     {
       fprintf (stderr, "ERROR: Could not init gfx!\n");

--- a/src/main.c
+++ b/src/main.c
@@ -59,7 +59,7 @@
 struct map *g_map;
 struct map_view *g_mapview;
 
-dict_t *config;
+dict_t *g_config;
 
 int g_running;
 
@@ -84,12 +84,12 @@ init (void)
 {
   char *module_path;
   
-  config = config_dict_init();
+  g_config = config_dict_init();
 
   /* yeah I know that needs someting better */
-  if (config_parse_file ("config/default.cfg", config) == SUCCESS)
+  if (config_parse_file ("config/default.cfg", g_config) == SUCCESS)
     {
-      module_path = config_get_value ("module_path", config);
+      module_path = config_get_value ("module_path", g_config);
     }
   else
     {
@@ -169,7 +169,7 @@ cleanup (void)
   cleanup_graphics ();
   cleanup_bindings ();
   cleanup_modules ();
-  config_free_dict (config);
+  config_free_dict (g_config);
 }
 
 /* vim: set ts=2 sw=2 softtabstop=2: */

--- a/src/main.c
+++ b/src/main.c
@@ -97,7 +97,7 @@ init (void)
 
       if (module_path == NULL)
         {
-          fprintf (stderr, "ERROR: Could not init modules!\n");
+          fatal ("MAIN - init - Module path could not be allocated.");
           return FAILURE;
         }
 
@@ -106,19 +106,19 @@ init (void)
 
   if (init_modules (module_path) == FAILURE)
     {
-      fprintf (stderr, "ERROR: Could not init modules!\n");
+      fatal ("MAIN - init - Module initialisation failed.");
       return FAILURE;
     }
 
   if (init_graphics () == FAILURE)
     {
-      fprintf (stderr, "ERROR: Could not init gfx!\n");
+      fatal ("MAIN - init - Graphics initialisation failed.");
       return FAILURE;
     }
 
   if (init_objects () == FAILURE)
     {
-      fprintf (stderr, "ERROR: Could not init objects!\n");
+      fatal ("MAIN - init - Object system initialisation failed.");
       return FAILURE;
     }
 
@@ -126,7 +126,7 @@ init (void)
 
   if (g_map == NULL)
     {
-      fprintf (stderr, "ERROR: Map did not init!\n");
+      fatal ("MAIN - init - Map initialisation failed.");
       return FAILURE;
     }
 
@@ -134,7 +134,7 @@ init (void)
 
   if (g_mapview == NULL)
     {
-      fprintf (stderr, "ERROR: Map view did not init!\n");
+      fatal ("MAIN - init - MapView initialisation failed.");
       return FAILURE;
     }
 

--- a/src/main.h
+++ b/src/main.h
@@ -50,6 +50,8 @@ extern int g_running;              /**< Whether or not the engine is
 extern struct map_view *g_mapview; /**< Main map view. 
                                       @todo FIXME: Move this? */
 
+extern struct dict_t *g_config;    /**< Configuration dictionary. */
+
 /** The main function.
  *
  *  @param argc  Argument count.

--- a/src/mapview.c
+++ b/src/mapview.c
@@ -330,6 +330,26 @@ render_map_layer (struct map_view *mapview, unsigned char layer)
   short x, y;
   int true_x, true_y, x_offset, y_offset;
   struct map *map;
+  struct hash_object *tileset_object;
+  void *tileset;
+
+  /* Try to grab the tileset. */
+
+  tileset_object = load_image (FN_TILESET);
+
+  if (tileset_object == NULL)
+    {
+      fprintf (stderr, "MAPVIEW: Error: Couldn't load tileset.\n");
+      return;
+    }
+
+  tileset = tileset_object->data;
+
+  if (tileset == NULL)
+    {
+      fprintf (stderr, "MAPVIEW: Error: Tileset has NULL data.\n");
+      return;
+    }
 
   map = mapview->map;
   x_offset = mapview->x_offset;
@@ -362,10 +382,12 @@ render_map_layer (struct map_view *mapview, unsigned char layer)
                   && true_y < map->height
                   && mapview->dirty_tiles[true_x + (true_y * map->height)] != 0)
                 {
+                  /* Use direct access to eliminate the need to
+                     continually hash the filename. */
                   if (map->data_layers[layer][true_x + (true_y * map->height)] 
                       != 0)
-                    draw_image (FN_TILESET,
-                                map->data_layers[layer][true_x 
+                    draw_image_direct (tileset,
+                                       map->data_layers[layer][true_x 
                                                         + (true_y * map->height)]
                                 * TILE_W, 0,
                                 (x * TILE_W) - (short) (x_offset % TILE_W),

--- a/src/mapview.h
+++ b/src/mapview.h
@@ -105,6 +105,23 @@ struct object_image
   struct object_image *next; /**< Next node in the queue. */
 };
 
+/** A dirty rectangle queue node. */
+
+struct dirty_rectangle
+{
+  int start_x; /**< X co-ordinate of the left edge of the rectangle
+                  (in tiles from left of map). */
+
+  int start_y; /**< Y co-ordinate of the top of the rectangle (in
+                  tiles from top of map). */
+
+  int width;   /**< Width of the rectangle (in tiles). */
+  int height;  /**< Height of the rectangle (in tiles). */
+
+  struct map_view *parent;      /**< Parent map view. */
+  struct dirty_rectangle *next; /**< Next node in the queue. */
+};
+
 /** A map viewpoint.
  *
  *  This contains data required to render a map, including the offset
@@ -146,6 +163,9 @@ struct map_view
                                          on the next pass.  There will
                                          be num_object_queues heads in
                                          this block.*/
+
+  struct dirty_rectangle *dirty_rectangles; /**< Stack of dirty
+                                               rectangles. */
 };
 
 #include "object.h" /* object_t; cannot be included before

--- a/src/object.c
+++ b/src/object.c
@@ -377,16 +377,18 @@ get_object (const char object_name[], struct hash_object *add_pointer)
 } 
 
 int
-dirty_object_test (struct hash_object *hash_object, va_list ap)
+dirty_object_test (struct hash_object *hash_object, void *rect_pointer)
 {
   struct object_t *object;
   struct map_view *mapview;
+  struct dirty_rectangle *rect;
+
   int start_x;
   int start_y;
   int width;
   int height;
 
-  /* Sanity-check the hash object. */
+  /* Sanity-check the hash object and dirty rectangle data. */
 
   if (hash_object == NULL)
     {
@@ -400,18 +402,24 @@ dirty_object_test (struct hash_object *hash_object, va_list ap)
       return FAILURE;
     }
 
+  if (rect_pointer == NULL)
+    {
+      fprintf (stderr, "OBJECT: Error: Given dirty rect pointer is NULL.\n");
+    }
+
   object = (struct object_t *) hash_object->data;
+  rect = (struct dirty_rectangle *) rect_pointer;
 
  /* If an object is already dirty, don't bother checking. */
 
   if (object->is_dirty == TRUE)
     return SUCCESS;
 
-  mapview = va_arg (ap, struct map_view *);
-  start_x = va_arg (ap, int);
-  start_y = va_arg (ap, int);
-  width   = va_arg (ap, int);
-  height  = va_arg (ap, int);
+  mapview = rect->parent;
+  start_x = rect->start_x;
+  start_y = rect->start_y;
+  width   = rect->width;
+  height  = rect->height;
 
   /* Use separating axis theorem, sort of, to decide whether the
      object rect and the dirty rect intersect. */

--- a/src/object.h
+++ b/src/object.h
@@ -271,19 +271,16 @@ get_object (const char object_name[], struct hash_object *add_pointer);
 /** Check to see whether the given object falls within the given dirty
  *  rectangle and, if so, mark the object as dirty.
  *
- *  @param hash_object  The hash container of the object to test.
+ *  @param hash_object   The hash container of the object to test.
  *
- *  @param ap           Variadic argument list.  This should be
- *                      composed of the mapview concerned followed by
- *                      the start X, start Y, width and height of the
- *                      dirty rectangle, in order.
+ *  @param rect_pointer  Void pointer to the dirty rectangle to test.
  *
  *  @return SUCCESS if there were no errors encountered; FAILURE
  *  otherwise.
  */
 
 int
-dirty_object_test (struct hash_object *hash_object, va_list ap);
+dirty_object_test (struct hash_object *hash_object, void *rect_pointer);
 
 /** Clean up the objects subsystem. */
 

--- a/src/util.c
+++ b/src/util.c
@@ -41,6 +41,44 @@
  *  @brief   Miscellaneous utility functions.
  */
 
-#include "util.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
 
-/* Space for rent */
+#include "util.h"
+#include "main.h"
+
+/* Fatal error. */
+
+void
+fatal (const char message[], ...)
+{
+  va_list ap;
+
+  va_start (ap, message);
+  fprintf (stderr, "FATAL: ");
+  vfprintf (stderr, message, ap);
+  fprintf (stderr, "\n");
+  va_end (ap);
+
+  fflush (stderr);
+
+  cleanup ();
+  exit (1);
+}
+
+/* Non-fatal error. */
+
+void
+error (const char message[], ...)
+{
+  va_list ap;
+
+  va_start (ap, message);
+  fprintf (stderr, "ERROR: ");
+  vfprintf (stderr, message, ap);
+  fprintf (stderr, "\n");
+  va_end (ap);
+
+  fflush (stderr);
+}

--- a/src/util.h
+++ b/src/util.h
@@ -48,6 +48,8 @@
 #ifndef _UTIL_H
 #define _UTIL_H
 
+#include <stdarg.h>
+
 /* -- CONSTANTS -- */
 
 enum
@@ -67,5 +69,31 @@ enum
 
 #define MAX(x, y) ((x) > (y) ? (x) : (y)) /**< Get the maximum of two
                                              values. */
+
+/* -- DECLARATIONS -- */
+
+/** Fatal error.
+ *
+ *  This prints an error message and sets the g_running variable to
+ *  FALSE, effectively causing the engine to try gracefully shut down
+ *  after the frame in progress.
+ * 
+ *  @param message  Message to print.  This wrapper automatically
+ *  prepends and appends FATAL: and a newline respectively. 
+ */
+
+void
+fatal (const char message[], ...);
+
+/** Non-fatal error.
+ *
+ *  This prints an error message only.
+ * 
+ *  @param message  Message to print.  This wrapper automatically
+ *  prepends and appends ERROR: and a newline respectively. 
+ */
+
+void
+error (const char message[], ...);
 
 #endif /* not _UTIL_H */


### PR DESCRIPTION
Notes:
- New fatal (const char message[], ...) and error (const char message[], ...) function wrappers in util. These should be used instead of fprintf (stderr, ...) for cleanliness, future expansion(?) and because fatal automatically calls cleanup and exits the code immediately (to be used, as you might have guessed, for fatal errors).
- Dirty rectangle code has been changed to use a queue for storing dirty rectangles and concentrating the effort of handling a run of recursive dirty rectangles on one main iterative loop, which should save the stack from being smashed with large amounts of objects. A side-effect is that the apply_to_hash_objects function now takes a void pointer of one data to pass to the function, instead of a va_list (this can change back if anyone can implement the non-standard va_copy)
