### PR TITLE
State

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -581,7 +581,7 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories
 # with spaces.
 
-INPUT                  = src/ src/modules/ src/tests/
+INPUT                  = src/ src/modules/ src/tests/ src/field/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is

--- a/Makefile
+++ b/Makefile
@@ -119,19 +119,19 @@ clean-doc:
 	-@$(RM) -r autodoc
 
 ### Test Suite
-tests: CFLAGS += -DTESTSUITE -DMODPATH="\"$(shell pwd)/$(TESTDIR)/$(MODDIR)\""
+tests: CFLAGS += -DTESTSUITE -DMODPATH="\"$(shell pwd)/$(TESTDIR)/$(MODDIR)/\""
 tests: $(TESTS)
 	@echo "Running tests..."
 	@for file in $(TESTS); do $$file &>/dev/null || echo "Test '$$file' failed."; done
 
-$(TESTDIR)/module: module.o $(TESTDIR)/module.o $(TESTDIR)/$(MODDIR)/test.so
-	@$(CC) $(CFLAGS) module.o $(TESTDIR)/module.o $(TESTDIR)/$(MODDIR)/test.so -o $@ >/dev/null
+$(TESTDIR)/module: $(SRCDIR)/module.o $(SRCDIR)/$(TESTDIR)/module.o $(SRCDIR)/$(TESTDIR)/$(MODDIR)/test.so
+	@$(CC) $(CFLAGS) $(SRCDIR)/module.o $(SRCDIR)/$(TESTDIR)/module.o -ldl -o $@ >/dev/null
 
-$(TESTDIR)/optionparser: optionparser.o $(TESTDIR)/optionparser.o
-	@$(CC) $(CFLAGS) optionparser.o $(TESTDIR)/optionparser.o -o $@ >/dev/null
+$(TESTDIR)/optionparser: $(SRCDIR)/optionparser.o $(SRCDIR)/$(TESTDIR)/optionparser.o
+	@$(CC) $(CFLAGS) $(SRCDIR)/optionparser.o $(SRCDIR)/$(TESTDIR)/optionparser.o -o $@ >/dev/null
 
-$(TESTDIR)/parser: parser.o $(TESTDIR)/parser.o
-	@$(CC) $(CFLAGS) parser.o $(TESTDIR)/parser.o -o $@ >/dev/null
+$(TESTDIR)/parser: $(SRCDIR)/parser.o $(SRCDIR)/$(TESTDIR)/parser.o
+	@$(CC) $(CFLAGS) $(SRCDIR)/parser.o $(SRCDIR)/$(TESTDIR)/parser.o -o $@ >/dev/null
 
 clean-tests:
 	@echo "Cleaning tests..."

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,9 @@ TESTS    := $(addprefix $(TESTDIR)/,$(TESTS))
 
 ## Objects to link into main executable ##
 
-OBJ      := main.o hash.o object.o graphics.o map.o mapview.o events.o
-OBJ      += util.o bindings.o module.o optionparser.o parser.o
+OBJ      := main.o hash.o graphics.o events.o
+OBJ      += util.o bindings.o module.o optionparser.o parser.o state.o
+OBJ      += field/field.o field/map.o field/mapview.o field/object.o
 
 # Add SRCDIR to all object paths #
 

--- a/src/events.c
+++ b/src/events.c
@@ -54,7 +54,12 @@
 #include "module.h"
 #include "util.h"
 
-static struct event_base *sg_event_base;
+/* -- STATIC GLOBAL VARIABLES -- */
+
+static struct event_base *sg_event_base; /**< Event base. */
+
+
+/* -- DEFINITIONS -- */
 
 int
 init_events (void)
@@ -80,15 +85,17 @@ init_events (void)
   return SUCCESS;
 }
 
-void cleanup_events (void)
+
+/* Process any events queued in the events driver. */
+
+void
+process_events (void)
 {
-  if (sg_event_base)
-    {
-      free (sg_event_base);
-      sg_event_base = NULL;
-    }
+  (*g_modules.event.process_events) ();
 }
 
+
+/* Install a callback. */
 
 struct event_callback *
 install_callback (void (*callback) (event_t *event), int types)
@@ -119,6 +126,8 @@ install_callback (void (*callback) (event_t *event), int types)
   return pnew;
 }
 
+
+/* Unload a callback. */
 
 int
 unload_callback (struct event_callback *ptr)
@@ -153,6 +162,9 @@ unload_callback (struct event_callback *ptr)
   return FAILURE;
 }
 
+
+/* Release an event package to all relevant installed callbacks. */
+
 void
 event_release (event_t *event)
 {
@@ -163,5 +175,18 @@ event_release (event_t *event)
       /* Trigger all callbacks with the relevant type. */
       if (p->types & event->type)
         p->callback (event);
+    }
+}
+
+
+/* De-initialise the events system. */
+
+void
+cleanup_events (void)
+{
+  if (sg_event_base)
+    {
+      free (sg_event_base);
+      sg_event_base = NULL;
     }
 }

--- a/src/events.c
+++ b/src/events.c
@@ -51,10 +51,7 @@
 #include <stdio.h>
 
 #include "events.h"
-#include "state.h"
 #include "module.h"
-#include "graphics.h"
-#include "field/mapview.h"
 #include "util.h"
 
 static struct event_base *sg_event_base;

--- a/src/events.c
+++ b/src/events.c
@@ -51,65 +51,20 @@
 #include <stdio.h>
 
 #include "events.h"
+#include "state.h"
 #include "module.h"
 #include "graphics.h"
-#include "mapview.h"
+#include "field/mapview.h"
 #include "util.h"
-#include "main.h"
 
 static struct event_base *sg_event_base;
-static unsigned char sg_held_special_keys[256];
-
-/* Test callbacks, woo */
-
-static event_callback *sg_skeyupcb;
-static event_callback *sg_skeydowncb;
-static event_callback *sg_quitcb;
-
-void
-on_quit (event_t *event)
-{
-  event = event;
-  g_running = 0;
-}
-
-void
-on_special_key_up (event_t *event)
-{
-  if (event->skey.code == SK_ESCAPE)
-    on_quit (event);
-
-  sg_held_special_keys[(int) event->skey.code] = 0;
-}
-
-void
-on_special_key_down (event_t *event)
-{
-  sg_held_special_keys[(int) event->skey.code] = 1;
-}
-
-void
-handle_held_keys (void)
-{
-  if (sg_held_special_keys[SK_UP])
-    scroll_map (g_mapview, NORTH);
-
-  if (sg_held_special_keys[SK_RIGHT])
-    scroll_map (g_mapview, EAST);
-
-  if (sg_held_special_keys[SK_DOWN])
-    scroll_map (g_mapview, SOUTH);
-
-  if (sg_held_special_keys[SK_LEFT])
-    scroll_map (g_mapview, WEST);
-}
 
 int
 init_events (void)
 {
   if (load_module_event ("event-sdl", &g_modules) == FAILURE)
     {
-      fprintf (stderr, "ERROR: Could not load events module.\n");
+      error ("EVENTS - init_events - Could not load events module.");
       return FAILURE;
     }
 
@@ -119,64 +74,22 @@ init_events (void)
 
   if (sg_event_base == NULL)
     {
-      fprintf (stderr, "ERROR: Could not allocate events base. \n");
+      error ("EVENTS - init_events - Could not allocate events base.");
       return FAILURE;
     }
 
   sg_event_base->callbacks = NULL;
-  memset (sg_held_special_keys, 0, sizeof (unsigned char) * 256);
-
-  /* Test callbacks, woo */
-
-  if (init_callbacks () == FAILURE)
-    {
-      fprintf (stderr, "ERROR: Could not install event callbacks.\n");
-    }
 
   return SUCCESS;
 }
 
-int
-init_callbacks (void)
-{
-  sg_skeyupcb = install_callback (on_special_key_up, SPECIAL_KEY_UP_EVENT);
-  sg_skeydowncb = install_callback (on_special_key_down, SPECIAL_KEY_DOWN_EVENT);
-  sg_quitcb = install_callback (on_quit, QUIT_EVENT);
-
-  if (sg_skeyupcb
-      && sg_skeydowncb
-      && sg_quitcb)
-    return SUCCESS;
-  else
-    {
-      /* Clean up callbacks if any failed. */
-      cleanup_callbacks ();
-      return FAILURE;
-    }
-}
-
-void
-cleanup_callbacks (void)
-{ 
- if (sg_skeyupcb)
-   unload_callback (sg_skeyupcb);
-
- if (sg_skeydowncb)
-   unload_callback (sg_skeydowncb);
-
- if (sg_quitcb)
-   unload_callback (sg_quitcb);
-
- sg_skeyupcb = sg_skeydowncb = sg_quitcb = NULL;
-}
-
 void cleanup_events (void)
 {
-  if (sg_event_base) {
-    cleanup_callbacks ();
-    free (sg_event_base);
-    sg_event_base = NULL;
-  }
+  if (sg_event_base)
+    {
+      free (sg_event_base);
+      sg_event_base = NULL;
+    }
 }
 
 
@@ -209,6 +122,7 @@ install_callback (void (*callback) (event_t *event), int types)
   return pnew;
 }
 
+
 int
 unload_callback (struct event_callback *ptr)
 {
@@ -222,20 +136,22 @@ unload_callback (struct event_callback *ptr)
           sg_event_base->callbacks = ptr->next;
           free (ptr);
           return SUCCESS;
-    }
+        }
 
-    for (p = sg_event_base->callbacks; p->next != NULL; p = p->next) {
-      if (p->next == ptr) {
-        /* Now we've found the list node before this one, replace its 
-           next pointer with the to-be-unloaded node's next pointer. */
-        p->next = ptr->next;
+      for (p = sg_event_base->callbacks; p->next != NULL; p = p->next)
+        {
+          if (p->next == ptr)
+            {
+              /* Now we've found the list node before this one, replace its 
+                 next pointer with the to-be-unloaded node's next pointer. */
+              p->next = ptr->next;
 
-        /* Now delete the callback. */
-        free(ptr);
-        return SUCCESS;
-      }
+              /* Now delete the callback. */
+              free(ptr);
+              return SUCCESS;
+            }
+        }
     }
-  }
 
   return FAILURE;
 }

--- a/src/events.h
+++ b/src/events.h
@@ -44,6 +44,9 @@
 #ifndef _EVENTS_H
 #define _EVENTS_H
 
+
+/* -- CONSTANTS -- */
+
 enum
   {
     QUIT_EVENT              = (1<<0), /**< Identifier for low-level
@@ -76,6 +79,7 @@ enum
     SK_RIGHT                   /**< Identifier for down arrow special key. */
   };
 
+
 /* -- TYPEDEFS -- */
 
 typedef union event_t event_t;                /**< Input event type. */
@@ -85,6 +89,7 @@ typedef struct event_callback event_callback; /**< Input callback type. */
 /* -- STRUCTURES -- */
 
 /** The input system base structure. */
+
 struct event_base
 {
   struct event_callback *callbacks; /**< Linked list of callbacks. */
@@ -92,6 +97,7 @@ struct event_base
 
 
 /** A mouse motion input event. */
+
 struct mouse_motion_event
 {
   unsigned char type;  /**< The type identifier of the input event. */
@@ -109,6 +115,7 @@ struct mouse_motion_event
 
 
 /** A mouse button input event. */
+
 struct mouse_button_event
 {
   unsigned char type;   /**< The type identifier of the input event. */ 
@@ -117,6 +124,7 @@ struct mouse_button_event
 
 
 /** An ASCII keyboard event. */
+
 struct ascii_key_event
 {
   unsigned char type; /**< Whether the key was pressed or released. */
@@ -125,6 +133,7 @@ struct ascii_key_event
 
 
 /** A special (non-ASCII) keyboard event. */
+
 struct special_key_event
 {
   unsigned char type; /**< Whether the key was pressed or released. */
@@ -133,6 +142,7 @@ struct special_key_event
 
 
 /** An input event package. */
+
 union event_t
 {
   unsigned char type;   /**< The type identifier of the input event. */
@@ -144,11 +154,13 @@ union event_t
 
 
 /** A callback node. */
+
 struct event_callback
 {
   void
   (*callback) (event_t *event); /**< The callback function
                                      pointer. */
+
   int types;                    /**< Types of event that will
                                      trigger the callback. */
 
@@ -168,10 +180,10 @@ int
 init_events (void);
 
 
-/** De-initialise the events system. */
+/** Process any events queued in the events driver. */
 
 void
-cleanup_events (void);
+process_events (void);
 
 
 /** Install a callback.
@@ -214,6 +226,12 @@ unload_callback (struct event_callback *callback);
 
 void
 event_release (event_t *event);
+
+
+/** De-initialise the events system. */
+
+void
+cleanup_events (void);
 
 
 #endif /* not _EVENTS_H */

--- a/src/events.h
+++ b/src/events.h
@@ -76,14 +76,20 @@ enum
     SK_RIGHT                   /**< Identifier for down arrow special key. */
   };
 
+/* -- TYPEDEFS -- */
+
 typedef union event_t event_t;                /**< Input event type. */
 typedef struct event_callback event_callback; /**< Input callback type. */
+
+
+/* -- STRUCTURES -- */
 
 /** The input system base structure. */
 struct event_base
 {
   struct event_callback *callbacks; /**< Linked list of callbacks. */
 };
+
 
 /** A mouse motion input event. */
 struct mouse_motion_event
@@ -101,12 +107,14 @@ struct mouse_motion_event
   short deltay; /**< Change in Y co-ordinate from previous position. */
 };
 
+
 /** A mouse button input event. */
 struct mouse_button_event
 {
   unsigned char type;   /**< The type identifier of the input event. */ 
   unsigned char button; /**< Which button was pressed. */
 };
+
 
 /** An ASCII keyboard event. */
 struct ascii_key_event
@@ -149,6 +157,8 @@ struct event_callback
 };
 
 
+/* -- PROTOTYPES -- */
+
 /** Initialise the events system.
  *
  *  @return SUCCESS for success, FAILURE for failure.
@@ -157,10 +167,12 @@ struct event_callback
 int
 init_events (void);
 
+
 /** De-initialise the events system. */
 
 void
 cleanup_events (void);
+
 
 /** Install a callback.
  *
@@ -180,6 +192,7 @@ struct event_callback *
 install_callback (void (*callback) (event_t *event),
                   int types);
 
+
 /** Unload a callback.
  *
  *  @see install_callback()
@@ -193,6 +206,7 @@ install_callback (void (*callback) (event_t *event),
 int 
 unload_callback (struct event_callback *callback);
 
+
 /** Release an event package to all relevant callbacks.
  *
  *  @param event  The event to release to callbacks.
@@ -201,48 +215,5 @@ unload_callback (struct event_callback *callback);
 void
 event_release (event_t *event);
 
-/* This stuff will likely be going away soon. */
 
-/** Initialise input callbacks.
- *
- *  @return SUCCESS for success, FAILURE otherwise.
- */
-
-int
-init_callbacks (void);
-
-/** De-initialise input callbacks. */
-
-void
-cleanup_callbacks (void);
-
-/** Callback for quit. 
- *
- *  @param event  The event produced by the quit.
- */
-
-void
-on_quit (event_t *event);
-
-/** Callback for special key up-presses. 
- *
- *  @param event The event produced by the key press.
- */
-
-void
-on_special_key_up (event_t *event);
-
-/** Callback for special key down-presses. 
- *
- *  @param event The event produced by the key press.
- */
-
-void
-on_special_key_down (event_t *event);
-
-/** Check to see if certain keys are held and handle the results. */
-
-void
-handle_held_keys (void);
-
-#endif /* _EVENTS_H */
+#endif /* not _EVENTS_H */

--- a/src/field/field.c
+++ b/src/field/field.c
@@ -1,0 +1,205 @@
+/*
+ * Crystals (working title)
+ *
+ * Copyright (c) 2010 Matt Windsor, Michael Walker and Alexander
+ *                    Preisinger.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *
+ *   * The names of contributors may not be used to endorse or promote
+ *     products derived from this software without specific prior
+ *     written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AFOREMENTIONED COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @file     src/field/field.c
+ *  @author   Matt Windsor
+ *  @brief    Field state.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "../util.h"
+#include "../events.h"
+#include "../state.h"
+
+#include "field.h"
+#include "map.h"
+#include "mapview.h"
+#include "object.h"
+
+
+struct map *sg_map;
+struct map_view *sg_mapview;
+
+/* Test callbacks, woo */
+
+static unsigned char sg_field_held_special_keys[256];
+
+static event_callback *sg_field_skeyupcb;
+static event_callback *sg_field_skeydowncb;
+static event_callback *sg_field_quitcb;
+
+/* -- DEFINITIONS -- */
+
+/* Callbacks */
+
+void
+field_on_quit (event_t *event)
+{
+  event = event;
+  set_state (STATE_QUIT);
+}
+
+
+void
+field_on_special_key_up (event_t *event)
+{
+  if (event->skey.code == SK_ESCAPE)
+    field_on_quit (event);
+
+  sg_field_held_special_keys[(int) event->skey.code] = 0;
+}
+
+
+void
+field_on_special_key_down (event_t *event)
+{
+  sg_field_held_special_keys[(int) event->skey.code] = 1;
+}
+
+/* Regular functions. */
+
+int
+init_field (void)
+{
+  memset (sg_field_held_special_keys, 0, sizeof (unsigned char) * 256);
+
+  /* Test callbacks, woo */
+
+  if (field_init_callbacks () == FAILURE)
+    {
+      fatal ("FIELD - init_field - Could not install event callbacks.");
+      return FAILURE;
+    }
+
+  sg_map = init_test_map ();
+
+  if (sg_map == NULL)
+    {
+      fatal ("FIELD - init_field - Map initialisation failed.");
+      return FAILURE;
+    }
+
+  sg_mapview = init_mapview (sg_map);
+
+  if (sg_mapview == NULL)
+    {
+      fatal ("FIELD - init_field - Map view initialisation failed.");
+      return FAILURE;
+    }
+
+  return SUCCESS;
+}
+
+
+void
+field_handle_held_keys (void)
+{
+  if (sg_field_held_special_keys[SK_UP])
+    scroll_map (sg_mapview, NORTH);
+
+  if (sg_field_held_special_keys[SK_RIGHT])
+    scroll_map (sg_mapview, EAST);
+
+  if (sg_field_held_special_keys[SK_DOWN])
+    scroll_map (sg_mapview, SOUTH);
+
+  if (sg_field_held_special_keys[SK_LEFT])
+    scroll_map (sg_mapview, WEST);
+}
+
+
+int
+field_init_callbacks (void)
+{
+  sg_field_skeyupcb = install_callback (field_on_special_key_up, SPECIAL_KEY_UP_EVENT);
+  sg_field_skeydowncb = install_callback (field_on_special_key_down, SPECIAL_KEY_DOWN_EVENT);
+  sg_field_quitcb = install_callback (field_on_quit, QUIT_EVENT);
+
+  if (sg_field_skeyupcb
+      && sg_field_skeydowncb
+      && sg_field_quitcb)
+    return SUCCESS;
+  else
+    {
+      /* Clean up callbacks if any failed. */
+      field_cleanup_callbacks ();
+      return FAILURE;
+    }
+}
+
+
+void
+field_cleanup_callbacks (void)
+{ 
+  if (sg_field_skeyupcb)
+    unload_callback (sg_field_skeyupcb);
+
+  if (sg_field_skeydowncb)
+    unload_callback (sg_field_skeydowncb);
+
+  if (sg_field_quitcb)
+    unload_callback (sg_field_quitcb);
+
+  sg_field_skeyupcb = sg_field_skeydowncb = sg_field_quitcb = NULL;
+}
+
+/* Perform per-frame updates for field. */
+
+void
+update_field (void)
+{
+  render_map (sg_mapview);
+  field_handle_held_keys ();
+}
+
+
+
+/* De-initialise the field state. */
+
+int
+cleanup_field (void)
+{
+  cleanup_mapview (sg_mapview);
+  cleanup_map (sg_map);
+
+  field_cleanup_callbacks ();
+
+  return SUCCESS;
+}

--- a/src/field/field.c
+++ b/src/field/field.c
@@ -53,9 +53,10 @@
 #include "mapview.h"
 #include "object.h"
 
+/* -- STATIC GLOBAL VARIABLES -- */
 
-struct map *sg_map;
-struct map_view *sg_mapview;
+static struct map *sg_map;
+static struct map_view *sg_mapview;
 
 /* Test callbacks, woo */
 

--- a/src/field/field.c
+++ b/src/field/field.c
@@ -199,6 +199,7 @@ cleanup_field (void)
 {
   cleanup_mapview (sg_mapview);
   cleanup_map (sg_map);
+  cleanup_objects ();
 
   field_cleanup_callbacks ();
 

--- a/src/field/field.h
+++ b/src/field/field.h
@@ -1,5 +1,5 @@
 /*
- * Crystals (working title)
+ * Crystals (working title) 
  *
  * Copyright (c) 2010 Matt Windsor, Michael Walker and Alexander
  *                    Preisinger.
@@ -36,64 +36,84 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/** @file   src/bindings.h
- *  @author Alexander Preisinger
- *  @brief  Prototypes and declarations for generic language bindings.
+/** @file    src/field/map.h
+ *  @author  Matt Windsor
+ *  @brief   Prototypes and declarations for field state.
  */
 
-#ifndef _BINDINGS_H
-#define _BINDINGS_H
+#ifndef _FIELD_H
+#define _FIELD_H
 
-#include "field/mapview.h"
-
-/* -- STRUCTURES -- */
-
-/** Game Data struct
- *
- * Contains all information that will be passed to the bindings
- * for scripting purpose.
- *
- * @todo don't forget to add more here and asking hayashi what else to add.
- */
-
-struct game_data
-{
-  struct map_view *map_view; /**< Pointer to the mapview */
-};
-
-/* -- GLOBAL VARIABLES -- */
-
-extern struct game_data g_game_data; /**< global variable for the game_data
-                                          struct */
+#include "../events.h" /* event_t */
 
 /* -- PROTOTYPES -- */
 
-/** Init language bindings
+/** Initialise input callbacks.
  *
- *  @return Return SUCCESS if success else FAILURE
+ *  @return SUCCESS for success, FAILURE otherwise.
  */
 
-
 int
-init_bindings (void);
+field_init_callbacks (void);
 
-
-/** Cleanup language bindings */
+/** De-initialise input callbacks. */
 
 void
-cleanup_bindings(void);
+field_cleanup_callbacks (void);
+
+/** Callback for quit. 
+ *
+ *  @param event  The event produced by the quit.
+ */
+
+void
+field_on_quit (event_t *event);
+
+/** Callback for special key up-presses. 
+ *
+ *  @param event The event produced by the key press.
+ */
+
+void
+field_on_special_key_up (event_t *event);
 
 
-/** Executes the given file.
+/** Callback for special key down-presses. 
  *
- *  @param path   Path to the file.
+ *  @param event The event produced by the key press.
+ */
+
+void
+field_on_special_key_down (event_t *event);
+
+
+/** Check to see if certain keys are held and handle the results. */
+
+void
+field_handle_held_keys (void);
+
+
+/** Initialise the field state.
  *
- *  @return SUCCESS for success, FAILURE for failure.
+ *  @return  SUCCESS if no errors were encountered; FAILURE otherwise. 
  */
 
 int
-run_file (const char *path);
+init_field (void);
 
-#endif /* _BINDINGS_H */
 
-/* vim: set ts=2 sw=2 softtabstop=2: */
+/** Perform per-frame updates for field. */
+
+void
+update_field (void);
+
+
+/** De-initialise the field state.
+ *
+ *  @return  SUCCESS if no errors were encountered; FAILURE otherwise. 
+ */
+
+int
+cleanup_field (void);
+
+#endif /* not _FIELD_H */

--- a/src/field/field.h
+++ b/src/field/field.h
@@ -36,7 +36,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/** @file    src/field/map.h
+/** @file    src/field/field.h
  *  @author  Matt Windsor
  *  @brief   Prototypes and declarations for field state.
  */

--- a/src/field/map.c
+++ b/src/field/map.c
@@ -46,8 +46,7 @@
 #include <string.h>
 
 #include "map.h"
-#include "main.h"
-#include "graphics.h"
+#include "../graphics.h"
 
 const char FN_TILESET[] = "gfx/tiles.png";
 

--- a/src/field/map.c
+++ b/src/field/map.c
@@ -36,7 +36,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/** @file    map.c
+/** @file    src/field/map.c
  *  @author  Matt Windsor
  *  @brief   Low-level map handling functions.
  */

--- a/src/field/map.h
+++ b/src/field/map.h
@@ -36,7 +36,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/** @file    map.h
+/** @file    src/field/map.h
  *  @author  Matt Windsor
  *  @brief   Prototypes and declarations for low-level map handling
  *           functions.

--- a/src/field/mapview.c
+++ b/src/field/mapview.c
@@ -36,7 +36,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/** @file    mapview.c
+/** @file    src/field/mapview.c
  *  @author  Matt Windsor
  *  @brief   Map rendering functions.
  */
@@ -49,11 +49,10 @@
 
 #include "mapview.h"
 #include "map.h"
-#include "util.h"
-#include "module.h"
-#include "graphics.h"
-
 #include "object.h"
+#include "../util.h"
+#include "../module.h"
+#include "../graphics.h"
 
 /* -- CONSTANTS -- */
 

--- a/src/field/mapview.h
+++ b/src/field/mapview.h
@@ -36,7 +36,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/** @file    mapview.h
+/** @file    src/field/mapview.h
  *  @author  Matt Windsor
  *  @brief   Prototypes and declarations for rendering functions.
  *

--- a/src/field/object.c
+++ b/src/field/object.c
@@ -36,7 +36,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/** @file    object.c
+/** @file    src/field/object.c
  *  @author  Matt Windsor
  *  @brief   Low-level object functions.
  */
@@ -46,8 +46,7 @@
 #include <string.h>
 
 #include "object.h"
-#include "main.h"
-#include "util.h"
+#include "../util.h"
 
 struct hash_object *g_objects[HASH_VALS];
 

--- a/src/field/object.h
+++ b/src/field/object.h
@@ -36,7 +36,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/** @file    object.h
+/** @file    src/field/object.h
  *  @author  Matt Windsor
  *  @brief   Prototypes and declarations for low-level object
  *           functions.
@@ -47,7 +47,7 @@
 
 #include <stdarg.h>
 
-#include "hash.h"    /* Hash stuff. */
+#include "../hash.h" /* Hash stuff. */
 #include "map.h"     /* layer_t */
 #include "mapview.h" /* struct object_image, struct map_view */
 

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -83,6 +83,16 @@ init_graphics (void)
   return SUCCESS;
 }
 
+
+/* Update the screen. */
+
+void
+update_screen (void)
+{
+  (*g_modules.gfx.update_screen) ();
+}
+
+
 /* Fill the screen with the given colour. */
 
 void
@@ -92,6 +102,7 @@ fill_screen (unsigned char red,
 {
   (*g_modules.gfx.draw_rect) (0, 0, SCREEN_W, SCREEN_H, red, green, blue);
 }
+
 
 /* Load an image. */
 
@@ -149,6 +160,7 @@ load_image (const char filename[])
   return image;
 }
 
+
 /* Free image data. */
 
 void
@@ -161,6 +173,7 @@ free_image (void *image)
 
   (*g_modules.gfx.free_image_data) (image);
 }
+
 
 
 /* Draw a rectangular portion of an image on-screen. */
@@ -237,6 +250,7 @@ clear_images (void)
   clear_hash_objects (sg_images);
 }
 
+
 /* Retrieve an image from the image cache. */
 
 struct hash_object *
@@ -244,6 +258,7 @@ find_image (const char filename[])
 {
   return get_hash_object (sg_images, filename, NULL);
 }
+
 
 /* Clean up the graphics subsystem. */
 

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -46,6 +46,8 @@
 
 #include "hash.h"    /* Hash stuff. */
 
+/* -- CONSTANTS -- */
+
 enum
   {
     SCREEN_W = 640, /**< Width of the screen (in pixels). 
@@ -59,6 +61,8 @@ enum
   };
 
 
+/* -- PROTOTYPES -- */
+
 /** Initialise the graphics subsystem.
  *
  *  @return  SUCCESS if the graphics subsystem was initialised
@@ -67,6 +71,12 @@ enum
 
 int
 init_graphics (void);
+
+
+/** Update the screen. */
+
+void
+update_screen (void);
 
 
 /** Fill the screen with the given colour.

--- a/src/hash.c
+++ b/src/hash.c
@@ -46,9 +46,9 @@
 #include <stdio.h>
 
 #include "hash.h"
-#include "util.h"     /* SUCCESS and FAILURE. */
-#include "graphics.h" /* free_image. */
-#include "object.h"   /* free_object. */
+#include "util.h"         /* SUCCESS and FAILURE. */
+#include "graphics.h"     /* free_image. */
+#include "field/object.h" /* free_object. */
 
 int
 ascii_hash (const char string[])

--- a/src/main.c
+++ b/src/main.c
@@ -48,14 +48,11 @@
 #include "main.h"
 #include "util.h"
 #include "state.h"
-#include "field/object.h"
 #include "parser.h"
 #include "module.h"
 #include "events.h"
 #include "graphics.h"
 #include "bindings.h"
-#include "field/mapview.h"
-#include "field/map.h"
 
 dict_t *g_config;
 

--- a/src/main.c
+++ b/src/main.c
@@ -54,7 +54,14 @@
 #include "graphics.h"
 #include "bindings.h"
 
+/* -- GLOBAL VARIABLES -- */
+
 dict_t *g_config;
+
+
+/* -- DEFINITIONS -- */
+
+/* The main function. */
 
 int
 main (int argc, char **argv)
@@ -69,6 +76,9 @@ main (int argc, char **argv)
   cleanup ();
   return 0;
 }
+
+
+/* Initialise all engine subsystems. */
 
 int
 init (void)
@@ -117,11 +127,7 @@ init (void)
   run_file ("tests/lua.lua");
   init_events ();
 
-  /* We need to manually "flush" the state so the first state is set
-     immediately instead of after a main loop frame - otherwise, the
-     current state would be null and the engine would crash. */
-
-  if (set_state (STATE_FIELD == FAILURE))
+  if (set_state (STATE_FIELD) == FAILURE)
     {
       fatal ("MAIN - init - Couldn't enqueue state.");
       return FAILURE;
@@ -131,16 +137,21 @@ init (void)
 }
 
 
+/* Execute the main loop of the program. */
+
 void
 main_loop (void)
 {
   while (update_state () != STATE_QUIT)
     {
       state_frame_updates ();
-      (*g_modules.gfx.update_screen) ();
-      (*g_modules.event.process_events) ();
+      update_screen ();
+      process_events ();
     }
 }
+
+
+/* Clean up all initialised subsystems. */
 
 void
 cleanup (void)
@@ -148,12 +159,12 @@ cleanup (void)
   if (get_state () != STATE_QUIT)
     cleanup_state (get_state ());
 
-  cleanup_objects ();
   cleanup_events ();
   cleanup_graphics ();
   cleanup_bindings ();
   cleanup_modules ();
   config_free_dict (g_config);
 }
+
 
 /* vim: set ts=2 sw=2 softtabstop=2: */

--- a/src/main.h
+++ b/src/main.h
@@ -44,9 +44,6 @@
 #ifndef _MAIN_H
 #define _MAIN_H
 
-extern int g_running;              /**< Whether or not the engine is 
-                                      running. */
-
 extern struct map_view *g_mapview; /**< Main map view. 
                                       @todo FIXME: Move this? */
 

--- a/src/state.c
+++ b/src/state.c
@@ -1,0 +1,186 @@
+/*
+ * Crystals (working title)
+ *
+ * Copyright (c) 2010 Matt Windsor, Michael Walker and Alexander
+ *                    Preisinger.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *
+ *   * The names of contributors may not be used to endorse or promote
+ *     products derived from this software without specific prior
+ *     written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AFOREMENTIONED COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @file     src/state.c
+ *  @author   Matt Windsor
+ *  @brief    Game state machine.
+ */
+
+#include "util.h"
+#include "state.h"
+
+#include "field/field.h"
+
+/* -- STATIC VARIABLES -- */
+
+static state_t sg_state = STATE_NULL;          /**< Current state. */
+static state_t sg_enqueued_state = STATE_NULL; /**< Enqueued state. */
+
+/* -- DEFINITIONS -- */
+
+/* Retrieve the current game state. */
+
+state_t
+get_state (void)
+{
+  return sg_state;
+}
+
+/* Change the current state. */
+
+int
+set_state (state_t new_state)
+{
+  /* Can't change state if we're already quitting, can't change state
+     to NULL,  and if we're trying to change to the current state then
+     there must be a logic error about. */
+
+  if (sg_state == STATE_QUIT)
+    {
+      error ("STATE - set_state - Tried to change state while quitting.");
+      return FAILURE;
+    }
+  else if (new_state == STATE_NULL)
+    {
+      error ("STATE - set_state - Tried to change to null state.");
+      return FAILURE;
+    }
+  else if (sg_state == new_state)
+    {
+      error ("STATE - set_state - Tried to change to current state.");
+      return FAILURE;
+    }
+
+  sg_enqueued_state = new_state;
+
+  return SUCCESS;
+}
+
+
+/* Process an enqueued state change, if any, and return the current state. */
+
+int
+update_state (void)
+{
+  /* Check to see if there is an enqueued (non-null) state. */
+
+  if (sg_enqueued_state == STATE_NULL)
+    return sg_state;
+
+  if (cleanup_state (sg_state) == FAILURE)
+    {
+      error ("STATE - set_state - Cleanup of old state failed.");
+      return STATE_NULL;
+    }
+
+  if (init_state (sg_enqueued_state) == FAILURE)
+    {
+      error ("STATE - set_state - Init of new state failed.");
+      return STATE_NULL;
+    }
+
+  sg_state = sg_enqueued_state;
+  sg_enqueued_state = STATE_NULL;
+
+  return sg_state;
+}
+
+
+/* Initialise a state. */
+
+int
+init_state (state_t state)
+{
+  switch (state)
+    {
+    case STATE_FIELD:
+      return init_field ();
+      break;
+    case STATE_QUIT:
+      return SUCCESS;
+      break;
+    default:
+      /* Invalid state. */
+      error ("STATE - init_state - Invalid state ID %u.", 
+             state);
+      return FAILURE;
+      break;
+    }
+}
+
+
+/* Perform frame updates for the current state. */
+
+void
+state_frame_updates (void)
+{
+  switch (sg_state)
+    {
+    case STATE_FIELD:
+      update_field ();
+      break;
+    default:
+      /* Invalid state. */
+      fatal ("STATE - state_frame_updates - Invalid state ID %u.", 
+             sg_state);
+      break;
+    }
+}
+
+
+/* Clean up a state. */
+
+int
+cleanup_state (state_t state)
+{
+  switch (state)
+    {
+    case STATE_FIELD:
+      return cleanup_field ();
+      break;
+    case STATE_NULL:
+      return SUCCESS;
+      break;
+    default:
+      /* Invalid state. */
+      error ("STATE - cleanup_state - Invalid state ID %u.", 
+             state);
+      return FAILURE;
+      break;
+    }
+}

--- a/src/state.c
+++ b/src/state.c
@@ -46,10 +46,12 @@
 
 #include "field/field.h"
 
-/* -- STATIC VARIABLES -- */
+
+/* -- STATIC GLOBAL VARIABLES -- */
 
 static state_t sg_state = STATE_NULL;          /**< Current state. */
 static state_t sg_enqueued_state = STATE_NULL; /**< Enqueued state. */
+
 
 /* -- DEFINITIONS -- */
 
@@ -60,6 +62,7 @@ get_state (void)
 {
   return sg_state;
 }
+
 
 /* Change the current state. */
 
@@ -104,13 +107,13 @@ update_state (void)
 
   if (cleanup_state (sg_state) == FAILURE)
     {
-      error ("STATE - set_state - Cleanup of old state failed.");
+      error ("STATE - update_state - Cleanup of old state failed.");
       return STATE_NULL;
     }
 
   if (init_state (sg_enqueued_state) == FAILURE)
     {
-      error ("STATE - set_state - Init of new state failed.");
+      error ("STATE - update_state - Init of new state failed.");
       return STATE_NULL;
     }
 

--- a/src/state.h
+++ b/src/state.h
@@ -1,0 +1,141 @@
+/*
+ * Crystals (working title)
+ *
+ * Copyright (c) 2010 Matt Windsor, Michael Walker and Alexander
+ *                    Preisinger.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *
+ *   * The names of contributors may not be used to endorse or promote
+ *     products derived from this software without specific prior
+ *     written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AFOREMENTIONED COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @file    src/state.h
+ *  @author  Matt Windsor
+ *  @brief   Prototypes and declarations for game state machine.
+ *
+ *  The game's master finite state machine directs the engine to
+ *  perform certain per-frame tasks depending on the current game
+ *  "state".  For example, if the game is in the state STATE_FIELD,
+ *  the engine will task itself with drawing the field map.
+ *  Similarly, in STATE_BATTLE the battle engine's operations will be
+ *  run instead.
+ */
+
+#ifndef _STATE_H
+#define _STATE_H
+
+/* -- TYPE DEFINITIONS -- */
+
+typedef unsigned char state_t; /**< State identifier type. */
+
+
+/* -- CONSTANTS -- */
+
+enum
+  {
+    STATE_NULL  = 0, /**< FSM null state. */
+    STATE_FIELD = 1, /**< FSM field map state. */
+    STATE_QUIT  = 42 /**< FSM quit state. */
+  };
+
+
+/* -- PROTOTYPES -- */
+
+/** Retrieve the current game state.
+ *
+ *  @return  the current game state. 
+ */
+
+state_t
+get_state (void);
+
+
+/** Change the current game state.
+ *
+ *  State changes are actually "lazy" - in order to ensure the
+ *  integrity of code executing directly after the state change, this
+ *  function does not actually immediately change the state but
+ *  instead enqueues a state change (facilitated by the function
+ *  change_to_enqueued_state) to occur at the beginning of the next
+ *  frame.
+ *
+ *  @param new_state  The state to attempt to change to.
+ *
+ *  @return  SUCCESS if no errors occurred, FAILURE otherwise (for
+ *  example, trying to enqueue a state change during a quit state).
+ */
+
+int
+set_state (state_t new_state);
+
+
+/** Process an enqueued state change, if any.
+ *
+ *  @return  The current state after any state changes, if
+ *           successful.  If there were errors, STATE_NULL (which can
+ *           never be changed to) will be returned, and can be trapped
+ *           as an error.
+ */
+
+int
+update_state (void);
+
+
+/** Call the initialising function for a given state.
+ *
+ *  @param state  The state to attempt to initialise.
+ *
+ *  @return  SUCCESS if no errors occurred, FAILURE otherwise.
+ */
+
+int
+init_state (state_t state);
+
+
+/** Perform per-frame updates for the current state. */
+
+void
+state_frame_updates (void);
+
+
+/** Call the cleanup function for a given state.
+ *
+ *  @param state  The state to attempt to de-initialise.
+ *
+ *  @return  SUCCESS if no errors occurred, FAILURE otherwise.
+ */
+
+int
+cleanup_state (state_t state);
+
+
+#endif /* not _STATE_H */
+
+/* vim: set ts=2 sw=2 softtabstop=2: */

--- a/src/tests/parser.c
+++ b/src/tests/parser.c
@@ -1,17 +1,66 @@
+/*
+ * Crystals (working title)
+ *
+ * Copyright (c) 2010 Matt Windsor, Michael Walker and Alexander
+ * Preisinger.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * * The names of contributors may not be used to endorse or promote
+ * products derived from this software without specific prior
+ * written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AFOREMENTIONED COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @file   src/tests/parser.c
+ *  @author Alexander Preisinger
+ *  @brief  Test suite for parser.
+ */
+
 #include "../parser.h"
 #include "../util.h"
 #include <stdio.h>
 
-int main(void)
+/** Main function.
+ *
+ *  @return  exit status.
+ */
+
+int
+main (void)
 {
-    dict_t *mydict = config_dict_init ();
+  dict_t *mydict = config_dict_init ();
 
-    if (config_parse_file ("../../config/default.cfg",mydict) == SUCCESS)
-        {
-            printf("module_path = %s\n", config_get_value("module_path", mydict));
-        }
+  if (config_parse_file ("../../config/default.cfg", mydict) == SUCCESS)
+    {
+      printf ("module_path = %s\n", config_get_value ("module_path", mydict));
+    }
 
-    config_free_dict (mydict);
-    return 0;
+  config_free_dict (mydict);
+  return 0;
 
 }


### PR DESCRIPTION
Major change to modular structure of code:
- A basic finite state machine to manage sections of game engine logic has been introduced. This will likely serve as the backbone for most more high-level engine functions. Main loop updates are now delegated to sections of code based on the current game state.
- object.c, map.c and mapview.c have now been moved into the "field" state (with new subdirectory field/), with a new code file field.c taking over initialisation, cleanup and frame updates for the state.
- Most of the events test code has moved into field.c and is init'd and cleanup'd by the field init and cleanup routines.
- g_running has been dropped. The replacement for the test (g_running == TRUE) is now (get_state () != STATE_QUIT).

Also, some riding changes:
- The update_screen (graphics) and process_events (events) driver functions are now wrapped by similarly named functions in graphics.c and event.c respectively, to help in encapsulating the driver system a bit more and making main_loop more readable..
- Some minor style cleanups, for which I am likely to be shot by other developers.

NOTE: The test suite is currently a bit broken (probably all my fault), and I would appreciate help in fixing it.
